### PR TITLE
v 0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
   <strong>Transform codebases into AI-ready formats with parsing, compression, and security analysis</strong>
 </p>
 
-[![Version](https://img.shields.io/badge/version-0.8.1-blue)](https://github.com/biostochastics/codeconcat) [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![Type checked: mypy](https://img.shields.io/badge/type%20checked-mypy-blue.svg)](http://mypy-lang.org/) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) [![Poetry](https://img.shields.io/badge/dependency%20management-poetry-blueviolet)](https://python-poetry.org/) [![Typer](https://img.shields.io/badge/CLI-typer-green)](https://typer.tiangolo.com/)
+[![Version](https://img.shields.io/badge/version-0.8.2-blue)](https://github.com/biostochastics/codeconcat) [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![Type checked: mypy](https://img.shields.io/badge/type%20checked-mypy-blue.svg)](http://mypy-lang.org/) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) [![Poetry](https://img.shields.io/badge/dependency%20management-poetry-blueviolet)](https://python-poetry.org/) [![Typer](https://img.shields.io/badge/CLI-typer-green)](https://typer.tiangolo.com/)
 
 ## Overview
 
-CodeConCat is a Python tool that transforms codebases into formats optimized for AI consumption and analysis. It automatically processes your code to extract functions, classes, imports, and documentation across 11+ programming languages. The tool provides structured output with context generation, making it ideal for sharing code with AI assistants and automated analysis.
+CodeConCat is a Python tool that transforms codebases into formats optimized for AI consumption and analysis. It automatically processes your code to extract functions, classes, imports, and documentation across 12+ programming languages. The tool provides structured output with context generation, making it ideal for sharing code with AI assistants and automated analysis.
 
 ### Security Features
 - **API access controls**: Configurable path access and authentication
@@ -23,7 +23,7 @@ CodeConCat is a Python tool that transforms codebases into formats optimized for
 
 ## Key Features
 
-- **Multi-Language Parsing**: Parsing for 11+ languages using tree-sitter and regex engines
+- **Multi-Language Parsing**: Parsing for 12+ languages using tree-sitter and regex engines
 - **AI Summarization** *(Optional)*: Code summarization using OpenAI, Anthropic, Google, OpenRouter, or local models
 - **Compression**: Code compression with pattern recognition and two simplified modes
 - **Security Scanning**: Integrated Semgrep support with configurable severity thresholds
@@ -53,6 +53,7 @@ CodeConCat provides comprehensive parsing for the following languages:
 | **PHP** | Yes | Yes | Traits, namespaces, attributes, typed properties |
 | **Julia** | Yes | Yes | Multiple dispatch, macros, type annotations |
 | **R** | Yes | Yes | S3/S4 classes, tidyverse, data.table |
+| **Swift** | Yes | Yes | Classes, structs, protocols, actors, SwiftUI, async/await |
 | **TOML** | No | Yes | Configuration parsing, nested tables |
 
 ### Parser Features
@@ -74,6 +75,7 @@ CodeConCat uses a multi-tier parser system for maximum reliability and feature c
    - Support for language-specific features and precise source locations
    - Handles nested declarations and complex constructs
    - Located in `codeconcat/parser/language_parsers/tree_sitter_{language}_parser.py`
+   - **New in v0.8.1**: Swift support via tree-sitter-swift grammar
 
 2. **Enhanced Regex Parsers** (Fallback)
    - Pattern-based parsing with state tracking
@@ -81,9 +83,9 @@ CodeConCat uses a multi-tier parser system for maximum reliability and feature c
    - Improved docstring extraction and handling
    - Located in `codeconcat/parser/language_parsers/enhanced_{language}_parser.py`
 
-3. **Legacy Parsers** (Being phased out)
-   - Original regex-based parsers
-   - Limited support for complex language features
+3. **Standard Regex Parsers**
+   - Reliable fallback for languages without tree-sitter support
+   - Swift parser includes comprehensive pattern matching for all language features
    - Located in `codeconcat/parser/language_parsers/{language}_parser.py`
 
 ### Parser Selection
@@ -933,6 +935,17 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 *Part of the Biostochastics collection of tools for translational science and biomarker discovery*
 
+## Recent Updates
+
+### Version 0.8.1
+- **Swift Language Support**: Full support for Swift parsing with both tree-sitter and regex engines
+  - Tree-sitter parser using [tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift) grammar
+  - Comprehensive regex fallback parser
+  - Support for modern Swift features: actors, async/await, property wrappers, SwiftUI
+  - Documentation comment extraction (/// and /** */)
+- **Enhanced AI Context**: Model-aware code truncation based on context windows
+- **Security Improvements**: Enhanced prompt injection prevention
+
 ## Acknowledgments
 
 CodeConCat is built with these open-source tools:
@@ -941,5 +954,6 @@ CodeConCat is built with these open-source tools:
 - [Rich](https://rich.readthedocs.io/) - Terminal formatting
 - [Poetry](https://python-poetry.org/) - Dependency management
 - [Tree-sitter](https://tree-sitter.github.io/) - Incremental parsing
+- [Tree-sitter Swift](https://github.com/alex-pinkus/tree-sitter-swift) - Swift grammar
 - [FastAPI](https://fastapi.tiangolo.com/) - Web API framework
 - [Pydantic](https://pydantic-docs.helpmanual.io/) - Data validation

--- a/codeconcat/parser/language_parsers/__init__.py
+++ b/codeconcat/parser/language_parsers/__init__.py
@@ -60,6 +60,7 @@ REGEX_PARSER_MAP = {
     "julia": "JuliaParser",
     "config": "TomlParser",
     "toml": "TomlParser",
+    "swift": "SwiftParser",
     # Enhanced parsers (preferred regex-based parsers)
     "python_enhanced": "EnhancedPythonParser",
     "csharp_enhanced": "EnhancedCSharpParser",
@@ -102,6 +103,7 @@ try:
         "rust": "TreeSitterRustParser",
         "julia": "TreeSitterJuliaParser",
         "r": "TreeSitterRParser",
+        "swift": "TreeSitterSwiftParser",
     }
 
     import logging

--- a/codeconcat/parser/language_parsers/swift_parser.py
+++ b/codeconcat/parser/language_parsers/swift_parser.py
@@ -1,0 +1,415 @@
+"""Swift language parser for CodeConCat."""
+
+import logging
+import re
+from typing import List, Set
+
+from ...base_types import Declaration, ParseResult, ParserInterface
+from ...errors import LanguageParserError
+
+logger = logging.getLogger(__name__)
+
+
+class SwiftParser(ParserInterface):
+    """Regex-based Swift parser implementing ParserInterface."""
+
+    def __init__(self):
+        """Initialize the Swift parser with regex patterns."""
+        # Import patterns for Swift
+        self.import_pattern = re.compile(r"^\s*import\s+(\S+)", re.MULTILINE)
+
+        # Typealias and associatedtype patterns
+        self.typealias_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate)\s+)*"
+            r"typealias\s+([A-Z]\w*)\s*=",
+            re.MULTILINE,
+        )
+
+        # Subscript patterns
+        self.subscript_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate|static)\s+)*"
+            r"subscript\s*\([^)]*\)",
+            re.MULTILINE,
+        )
+
+        # Class/Struct/Enum/Protocol/Actor/Extension patterns
+        self.type_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate|open|final)\s+)*"
+            r"(class|struct|enum|protocol|actor|extension)\s+"
+            r"([A-Z]\w*(?:<[^>]+>)?)",
+            re.MULTILINE,
+        )
+
+        # Function/Method patterns (including init, deinit, async/throws)
+        self.func_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate|open|static|override|mutating|async|throws|rethrows|@\w+)\s+)*"
+            r"(func|init|deinit)\s+([a-zA-Z_]\w*|\()?(?:<[^>]+>)?\s*\([^)]*\)",
+            re.MULTILINE,
+        )
+
+        # Property patterns (var/let) - improved to handle property wrappers
+        self.property_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate|open|static|lazy|weak|unowned|@\w+)\s+)*"
+            r"(var|let)\s+([a-zA-Z_]\w*)\s*:",
+            re.MULTILINE,
+        )
+
+        # Computed property patterns
+        self.computed_property_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate|open|static)\s+)*"
+            r"var\s+([a-zA-Z_]\w*)\s*:\s*[^{]+\s*\{",
+            re.MULTILINE,
+        )
+
+        # SwiftUI View patterns
+        self.swiftui_view_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate)\s+)*"
+            r"struct\s+(\w+)\s*:\s*(?:\w+\s*,\s*)*View",
+            re.MULTILINE,
+        )
+
+        # Protocol conformance patterns
+        self.protocol_conformance_pattern = re.compile(
+            r"^\s*(?:(?:public|private|internal|fileprivate|open|final)\s+)*"
+            r"(?:class|struct|enum|actor)\s+(\w+)\s*:\s*([^{]+)",
+            re.MULTILINE,
+        )
+
+        # Operator declaration patterns
+        self.operator_pattern = re.compile(
+            r"^\s*(?:(?:prefix|infix|postfix)\s+)?operator\s+([^\s{]+)", re.MULTILINE
+        )
+
+        # @main attribute pattern (entry point)
+        self.main_pattern = re.compile(
+            r"^\s*@main\s*\n\s*(struct|class|enum)\s+(\w+)", re.MULTILINE
+        )
+
+    def parse(self, content: str, file_path: str = "") -> ParseResult:
+        """Parse Swift source code to extract declarations and imports.
+
+        Args:
+            content: The Swift source code as a string
+            file_path: Optional path to the file being parsed
+
+        Returns:
+            ParseResult containing declarations and imports
+        """
+        try:
+            declarations = []
+            imports: Set[str] = set()
+            lines = content.split("\n")
+
+            # Extract imports
+            for match in self.import_pattern.finditer(content):
+                imports.add(match.group(1))
+
+            # Track what we've already found to avoid duplicates
+            found_declarations = set()
+
+            # Extract typealiases
+            for match in self.typealias_pattern.finditer(content):
+                name = match.group(1)
+                if name not in found_declarations:
+                    found_declarations.add(name)
+                    start_line = content[: match.start()].count("\n") + 1
+
+                    declarations.append(
+                        Declaration(
+                            kind="typealias",
+                            name=name,
+                            start_line=start_line,
+                            end_line=start_line,
+                            modifiers={"typealias"},
+                            docstring=self._extract_docstring(lines, start_line - 1),
+                        )
+                    )
+
+            # Extract type declarations (classes, structs, enums, protocols, actors, extensions)
+            for match in self.type_pattern.finditer(content):
+                kind = match.group(1)
+                name = match.group(2)
+
+                if name not in found_declarations:
+                    found_declarations.add(name)
+                    start_line = content[: match.start()].count("\n") + 1
+
+                    # Find the end of the declaration (simple heuristic)
+                    end_line = self._find_block_end(content, match.start(), start_line)
+
+                    # Extract any documentation comments above the declaration
+                    docstring = self._extract_docstring(lines, start_line - 1)
+
+                    declarations.append(
+                        Declaration(
+                            kind=kind,
+                            name=name,
+                            start_line=start_line,
+                            end_line=end_line,
+                            modifiers={kind},
+                            docstring=docstring,
+                        )
+                    )
+
+            # Extract SwiftUI Views (special handling)
+            for match in self.swiftui_view_pattern.finditer(content):
+                name = match.group(1)
+                if name not in found_declarations:
+                    found_declarations.add(name)
+                    start_line = content[: match.start()].count("\n") + 1
+                    end_line = self._find_block_end(content, match.start(), start_line)
+                    docstring = self._extract_docstring(lines, start_line - 1)
+
+                    declarations.append(
+                        Declaration(
+                            kind="struct",
+                            name=name,
+                            start_line=start_line,
+                            end_line=end_line,
+                            modifiers={"struct", "View"},
+                            docstring=docstring,
+                        )
+                    )
+
+            # Extract functions and methods
+            for match in self.func_pattern.finditer(content):
+                func_type = match.group(1)  # 'func', 'init', or 'deinit'
+                func_name = match.group(2) if match.group(2) else func_type
+
+                # For init/deinit, the name is the type itself
+                if func_type in ["init", "deinit"]:
+                    func_name = func_type
+
+                # Create unique identifier for deduplication
+                start_line = content[: match.start()].count("\n") + 1
+                func_id = f"{func_name}_{start_line}"
+
+                if func_id not in found_declarations:
+                    found_declarations.add(func_id)
+                    end_line = self._find_block_end(content, match.start(), start_line)
+                    docstring = self._extract_docstring(lines, start_line - 1)
+
+                    kind_mapping = {
+                        "func": "function",
+                        "init": "initializer",
+                        "deinit": "deinitializer",
+                    }
+                    declarations.append(
+                        Declaration(
+                            kind=kind_mapping.get(func_type, "function"),
+                            name=func_name,
+                            start_line=start_line,
+                            end_line=end_line,
+                            modifiers={kind_mapping.get(func_type, "function")},
+                            docstring=docstring,
+                            signature=match.group(0).strip(),
+                        )
+                    )
+
+            # Extract properties
+            for match in self.property_pattern.finditer(content):
+                prop_type = match.group(1)  # 'var' or 'let'
+                prop_name = match.group(2)
+
+                prop_id = f"prop_{prop_name}"
+                if prop_id not in found_declarations:
+                    found_declarations.add(prop_id)
+                    start_line = content[: match.start()].count("\n") + 1
+
+                    declarations.append(
+                        Declaration(
+                            kind="property",
+                            name=prop_name,
+                            start_line=start_line,
+                            end_line=start_line,  # Properties are usually single line
+                            modifiers={"property", prop_type},
+                            docstring="",
+                        )
+                    )
+
+            # Extract computed properties
+            for match in self.computed_property_pattern.finditer(content):
+                prop_name = match.group(1)
+
+                comp_prop_id = f"computed_{prop_name}"
+                if comp_prop_id not in found_declarations:
+                    found_declarations.add(comp_prop_id)
+                    start_line = content[: match.start()].count("\n") + 1
+                    end_line = self._find_block_end(content, match.start(), start_line)
+                    docstring = self._extract_docstring(lines, start_line - 1)
+
+                    declarations.append(
+                        Declaration(
+                            kind="computed_property",
+                            name=prop_name,
+                            start_line=start_line,
+                            end_line=end_line,
+                            modifiers={"property", "computed"},
+                            docstring=docstring,
+                        )
+                    )
+
+            # Extract subscripts
+            for match in self.subscript_pattern.finditer(content):
+                start_line = content[: match.start()].count("\n") + 1
+                sub_id = f"subscript_{start_line}"
+
+                if sub_id not in found_declarations:
+                    found_declarations.add(sub_id)
+                    end_line = self._find_block_end(content, match.start(), start_line)
+                    docstring = self._extract_docstring(lines, start_line - 1)
+
+                    declarations.append(
+                        Declaration(
+                            kind="subscript",
+                            name="subscript",
+                            start_line=start_line,
+                            end_line=end_line,
+                            modifiers={"subscript"},
+                            docstring=docstring,
+                            signature=match.group(0).strip(),
+                        )
+                    )
+
+            # Extract operators
+            for match in self.operator_pattern.finditer(content):
+                op_name = match.group(1)
+                start_line = content[: match.start()].count("\n") + 1
+
+                declarations.append(
+                    Declaration(
+                        kind="operator",
+                        name=op_name,
+                        start_line=start_line,
+                        end_line=start_line,
+                        modifiers={"operator"},
+                        docstring="",
+                    )
+                )
+
+            # Extract @main entry points
+            for match in self.main_pattern.finditer(content):
+                kind = match.group(1)
+                name = match.group(2)
+
+                if f"main_{name}" not in found_declarations:
+                    found_declarations.add(f"main_{name}")
+                    start_line = content[: match.start()].count("\n") + 1
+                    end_line = self._find_block_end(content, match.start(), start_line)
+
+                    declarations.append(
+                        Declaration(
+                            kind=kind,
+                            name=name,
+                            start_line=start_line,
+                            end_line=end_line,
+                            modifiers={kind, "main"},
+                            docstring=self._extract_docstring(lines, start_line - 1),
+                        )
+                    )
+
+            logger.debug(
+                f"Parsed Swift file {file_path}: {len(declarations)} declarations, {len(imports)} imports"
+            )
+
+            return ParseResult(
+                declarations=declarations,
+                imports=sorted(imports),
+                engine_used="regex",
+                file_path=file_path,
+                language="swift",
+                content=content,
+            )
+
+        except Exception as e:
+            logger.error(f"Error parsing Swift file {file_path}: {e}", exc_info=True)
+            raise LanguageParserError(
+                message=f"Failed to parse Swift file: {e}",
+                file_path=file_path,
+                original_exception=e,
+            ) from e
+
+    def _find_block_end(self, content: str, start_pos: int, start_line: int) -> int:
+        """Find the end line of a code block starting from a position.
+
+        Simple heuristic: count braces to find matching closing brace.
+        """
+        content_after = content[start_pos:]
+        lines_after = content_after.split("\n")
+
+        brace_count = 0
+        found_opening = False
+
+        for i, line in enumerate(lines_after):
+            # Count braces, ignoring those in strings/comments
+            clean_line = self._remove_strings_and_comments(line)
+
+            if "{" in clean_line:
+                found_opening = True
+                brace_count += clean_line.count("{")
+            if "}" in clean_line:
+                brace_count -= clean_line.count("}")
+
+            if found_opening and brace_count == 0:
+                return start_line + i
+
+        # If no closing brace found, return start_line + 1
+        return start_line + 1
+
+    def _remove_strings_and_comments(self, line: str) -> str:
+        """Remove string literals and comments from a line for brace counting."""
+        # Remove single-line comments
+        if "//" in line:
+            line = line[: line.index("//")]
+
+        # Remove string literals (simple approach)
+        # This is not perfect but good enough for brace counting
+        line = re.sub(r'"[^"]*"', "", line)
+        line = re.sub(r"'[^']*'", "", line)
+
+        return line
+
+    def _extract_docstring(self, lines: List[str], decl_line_idx: int) -> str:
+        """Extract documentation comments above a declaration.
+
+        Swift uses /// for single-line doc comments and /** */ for multi-line.
+        """
+        if decl_line_idx < 0:
+            return ""
+
+        doc_lines: List[str] = []
+        i = decl_line_idx
+
+        # Look backwards for documentation comments
+        while i >= 0:
+            line = lines[i].strip()
+
+            # Single-line doc comment
+            if line.startswith("///"):
+                doc_lines.insert(0, line[3:].strip())
+                i -= 1
+            # Multi-line doc comment end
+            elif line.endswith("*/"):
+                # Find the start of the multi-line comment
+                for j in range(i, -1, -1):
+                    if "/**" in lines[j]:
+                        # Extract the multi-line comment
+                        for k in range(j, i + 1):
+                            comment_line = lines[k].strip()
+                            if comment_line.startswith("/**"):
+                                comment_line = comment_line[3:].strip()
+                            elif comment_line.endswith("*/"):
+                                comment_line = comment_line[:-2].strip()
+                            elif comment_line.startswith("*"):
+                                comment_line = comment_line[1:].strip()
+                            if comment_line:
+                                doc_lines.append(comment_line)
+                        break
+                break
+            # Not a doc comment, stop looking
+            elif line and not line.startswith("//"):
+                break
+            else:
+                i -= 1
+
+        return "\n".join(doc_lines)

--- a/codeconcat/parser/language_parsers/tree_sitter_swift_parser.py
+++ b/codeconcat/parser/language_parsers/tree_sitter_swift_parser.py
@@ -1,0 +1,518 @@
+"""Tree-sitter based Swift parser for CodeConCat."""
+
+import logging
+from typing import Dict, List
+
+from tree_sitter import Node
+
+from ...base_types import Declaration
+from .base_tree_sitter_parser import BaseTreeSitterParser
+
+logger = logging.getLogger(__name__)
+
+# Tree-sitter queries for Swift
+SWIFT_QUERIES = {
+    "imports": """
+        ; Import declarations
+        (import_declaration) @import
+    """,
+    "declarations": """
+        ; Class declarations
+        (class_declaration
+            name: (type_identifier) @name
+        ) @class
+
+        ; Structure declarations
+        (struct_declaration
+            name: (type_identifier) @name
+        ) @struct
+
+        ; Enum declarations
+        (enum_declaration
+            name: (type_identifier) @name
+        ) @enum
+
+        ; Protocol declarations
+        (protocol_declaration
+            name: (type_identifier) @name
+        ) @protocol
+
+        ; Actor declarations (Swift 5.5+)
+        (actor_declaration
+            name: (type_identifier) @name
+        ) @actor
+
+        ; Extension declarations
+        (extension_declaration
+            name: (type_identifier) @name
+        ) @extension
+
+        ; Function declarations
+        (function_declaration
+            name: (simple_identifier) @name
+        ) @function
+
+        ; Method declarations
+        (function_declaration
+            name: (simple_identifier) @name
+        ) @method
+
+        ; Initializer declarations
+        (initializer_declaration) @initializer
+
+        ; Deinitializer declarations
+        (deinitializer_declaration) @deinitializer
+
+        ; Property declarations
+        (property_declaration
+            name: (pattern) @name
+        ) @property
+
+        ; Subscript declarations
+        (subscript_declaration) @subscript
+
+        ; Operator declarations
+        (operator_declaration
+            name: (custom_operator) @name
+        ) @operator
+
+        ; Typealias declarations
+        (typealias_declaration
+            name: (type_identifier) @name
+        ) @typealias
+
+        ; Associated type declarations
+        (associatedtype_declaration
+            name: (type_identifier) @name
+        ) @associatedtype
+
+        ; Global variable/constant declarations
+        (property_declaration
+            name: (pattern (simple_identifier) @name)
+        ) @global_var
+    """,
+    "doc_comments": """
+        ; Documentation comments (///)
+        (comment) @doc_comment (#match? @doc_comment "^///")
+
+        ; Block documentation comments (/** */)
+        (multiline_comment) @doc_block (#match? @doc_block "^/\\\\*\\\\*")
+
+        ; Regular comments
+        (comment) @comment
+        (multiline_comment) @multiline_comment
+    """,
+}
+
+
+class TreeSitterSwiftParser(BaseTreeSitterParser):
+    """Tree-sitter based parser for Swift code."""
+
+    def __init__(self):
+        """Initialize the Swift parser."""
+        super().__init__("swift")
+        self.queries_dict = SWIFT_QUERIES
+        self._compiled_queries = {}
+
+    def get_queries(self) -> Dict[str, str]:
+        """Get the query strings for Swift parsing.
+
+        Returns:
+            Dictionary of query names to query strings
+        """
+        return SWIFT_QUERIES
+
+    def _get_compiled_query(self, query_name: str):
+        """Get a compiled query from cache or compile it.
+
+        This method uses the parent class's caching mechanism.
+        """
+        query_str = self.queries_dict.get(query_name)
+        if not query_str:
+            return None
+
+        # Use parent class's compile method with caching
+        cache_key = (self.language_name, query_name, query_str)
+        return self._compile_query_cached(cache_key)
+
+    def extract_imports(self, tree: Node, byte_content: bytes) -> List[str]:
+        """Extract import statements from Swift code.
+
+        Args:
+            tree: The tree-sitter parse tree
+
+        Returns:
+            List of imported module names
+        """
+        imports: List[str] = []
+        import_query = self._get_compiled_query("imports")
+
+        if not import_query:
+            return imports
+
+        try:
+            captures = import_query.captures(tree.root_node)
+
+            for node, capture_name in captures:
+                if capture_name == "import":
+                    # Extract the full import statement text
+                    import_text = byte_content[node.start_byte : node.end_byte].decode(
+                        "utf-8", errors="replace"
+                    )
+                    # Remove 'import' keyword and extract module name
+                    if import_text.startswith("import "):
+                        module_name = import_text[7:].strip()
+                        # Handle import attributes like @testable
+                        if module_name.startswith("@"):
+                            parts = module_name.split(None, 1)
+                            if len(parts) > 1:
+                                module_name = parts[1]
+                        imports.append(module_name)
+
+        except Exception as e:
+            logger.warning(f"Error extracting imports: {e}")
+
+        return imports
+
+    def extract_declarations(self, tree: Node, byte_content: bytes) -> List[Declaration]:
+        """Extract declarations from Swift code.
+
+        Args:
+            tree: The tree-sitter parse tree
+
+        Returns:
+            List of Declaration objects
+        """
+        declarations: List[Declaration] = []
+        decl_query = self._get_compiled_query("declarations")
+
+        if not decl_query:
+            return declarations
+
+        try:
+            captures = decl_query.captures(tree.root_node)
+
+            # Group captures by their parent nodes to avoid duplicates
+            processed_nodes = set()
+
+            for node, capture_name in captures:
+                # Skip if we've already processed this node
+                if id(node) in processed_nodes:
+                    continue
+
+                # Extract declaration based on type
+                if capture_name in ["class", "struct", "enum", "protocol", "actor", "extension"]:
+                    processed_nodes.add(id(node))
+                    name_node = self._find_name_node(node)
+                    if name_node:
+                        declarations.append(
+                            Declaration(
+                                kind=capture_name,
+                                name=byte_content[name_node.start_byte : name_node.end_byte].decode(
+                                    "utf-8", errors="replace"
+                                ),
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                                docstring=self._extract_docstring_for_node(
+                                    node, tree, byte_content
+                                ),
+                                modifiers=self._extract_modifiers(node, byte_content),
+                            )
+                        )
+
+                elif capture_name == "function":
+                    processed_nodes.add(id(node))
+                    name_node = self._find_name_node(node)
+                    if name_node:
+                        func_name = byte_content[name_node.start_byte : name_node.end_byte].decode(
+                            "utf-8", errors="replace"
+                        )
+                        # Check if it's async/throws
+                        modifiers = self._extract_function_modifiers(node, byte_content)
+                        declarations.append(
+                            Declaration(
+                                kind="function",
+                                name=func_name,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                                docstring=self._extract_docstring_for_node(
+                                    node, tree, byte_content
+                                ),
+                                modifiers=modifiers,
+                                signature=self._extract_function_signature(node, byte_content),
+                            )
+                        )
+
+                elif capture_name == "initializer":
+                    processed_nodes.add(id(node))
+                    declarations.append(
+                        Declaration(
+                            kind="initializer",
+                            name="init",
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                            docstring=self._extract_docstring_for_node(node, tree, byte_content),
+                            modifiers=self._extract_modifiers(node, byte_content),
+                        )
+                    )
+
+                elif capture_name == "deinitializer":
+                    processed_nodes.add(id(node))
+                    declarations.append(
+                        Declaration(
+                            kind="deinitializer",
+                            name="deinit",
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                            docstring=self._extract_docstring_for_node(node, tree, byte_content),
+                            modifiers=set(),
+                        )
+                    )
+
+                elif capture_name == "property":
+                    processed_nodes.add(id(node))
+                    name_node = self._find_property_name(node)
+                    if name_node:
+                        prop_name = byte_content[name_node.start_byte : name_node.end_byte].decode(
+                            "utf-8", errors="replace"
+                        )
+                        modifiers = self._extract_property_modifiers(node, byte_content)
+                        declarations.append(
+                            Declaration(
+                                kind="property",
+                                name=prop_name,
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                                docstring=self._extract_docstring_for_node(
+                                    node, tree, byte_content
+                                ),
+                                modifiers=modifiers,
+                            )
+                        )
+
+                elif capture_name == "subscript":
+                    processed_nodes.add(id(node))
+                    declarations.append(
+                        Declaration(
+                            kind="subscript",
+                            name="subscript",
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                            docstring=self._extract_docstring_for_node(node, tree, byte_content),
+                            modifiers=self._extract_modifiers(node, byte_content),
+                        )
+                    )
+
+                elif capture_name == "operator":
+                    processed_nodes.add(id(node))
+                    name_node = self._find_child_by_type(node, "custom_operator")
+                    if name_node:
+                        declarations.append(
+                            Declaration(
+                                kind="operator",
+                                name=byte_content[name_node.start_byte : name_node.end_byte].decode(
+                                    "utf-8", errors="replace"
+                                ),
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                                docstring="",
+                                modifiers=self._extract_operator_modifiers(node, byte_content),
+                            )
+                        )
+
+                elif capture_name == "typealias":
+                    processed_nodes.add(id(node))
+                    name_node = self._find_name_node(node)
+                    if name_node:
+                        declarations.append(
+                            Declaration(
+                                kind="typealias",
+                                name=byte_content[name_node.start_byte : name_node.end_byte].decode(
+                                    "utf-8", errors="replace"
+                                ),
+                                start_line=node.start_point[0] + 1,
+                                end_line=node.end_point[0] + 1,
+                                docstring=self._extract_docstring_for_node(
+                                    node, tree, byte_content
+                                ),
+                                modifiers=set(),
+                            )
+                        )
+
+        except Exception as e:
+            logger.warning(f"Error extracting declarations: {e}")
+
+        return declarations
+
+    def _find_name_node(self, node: Node) -> Node:
+        """Find the name identifier node within a declaration."""
+        # Look for type_identifier or simple_identifier
+        for child in node.children:
+            if child.type in ["type_identifier", "simple_identifier"]:
+                return child
+            # Check if child is 'name:' field
+            if node.child_by_field_name("name"):
+                return node.child_by_field_name("name")
+        return None
+
+    def _find_property_name(self, node: Node) -> Node:
+        """Find the property name within a property declaration."""
+        # Look for pattern containing the identifier
+        pattern = node.child_by_field_name("name")
+        if pattern:
+            # Navigate through pattern to find the actual identifier
+            for child in pattern.children:
+                if child.type == "simple_identifier":
+                    return child
+            # If pattern is directly the identifier
+            if pattern.type == "simple_identifier":
+                return pattern
+        return None
+
+    def _find_child_by_type(self, node: Node, child_type: str) -> Node:
+        """Find a child node by type."""
+        for child in node.children:
+            if child.type == child_type:
+                return child
+        return None
+
+    def _extract_modifiers(self, node: Node, byte_content: bytes) -> set:
+        """Extract access modifiers and other modifiers from a declaration."""
+        modifiers = set()
+
+        # Look for modifier nodes
+        for child in node.children:
+            if child.type == "modifiers":
+                for modifier in child.children:
+                    if modifier.type in [
+                        "visibility_modifier",
+                        "mutation_modifier",
+                        "property_modifier",
+                        "inheritance_modifier",
+                    ]:
+                        modifiers.add(
+                            byte_content[modifier.start_byte : modifier.end_byte].decode(
+                                "utf-8", errors="replace"
+                            )
+                        )
+            elif child.type in [
+                "public",
+                "private",
+                "internal",
+                "fileprivate",
+                "open",
+                "static",
+                "class",
+                "final",
+                "override",
+            ]:
+                modifiers.add(child.type)
+
+        return modifiers
+
+    def _extract_function_modifiers(self, node: Node, byte_content: bytes) -> set:
+        """Extract function-specific modifiers."""
+        modifiers = self._extract_modifiers(node, byte_content)
+
+        # Check for async/throws/rethrows
+        for child in node.children:
+            if child.type in ["async", "throws", "rethrows"]:
+                modifiers.add(child.type)
+            elif byte_content[child.start_byte : child.end_byte].decode(
+                "utf-8", errors="replace"
+            ) in ["async", "throws", "rethrows"]:
+                modifiers.add(
+                    byte_content[child.start_byte : child.end_byte].decode(
+                        "utf-8", errors="replace"
+                    )
+                )
+
+        modifiers.add("function")
+        return modifiers
+
+    def _extract_property_modifiers(self, node: Node, byte_content: bytes) -> set:
+        """Extract property-specific modifiers."""
+        modifiers = self._extract_modifiers(node, byte_content)
+
+        # Check for var/let
+        for child in node.children:
+            if child.type in ["let", "var"]:
+                modifiers.add(child.type)
+            elif byte_content[child.start_byte : child.end_byte].decode(
+                "utf-8", errors="replace"
+            ) in ["let", "var"]:
+                modifiers.add(
+                    byte_content[child.start_byte : child.end_byte].decode(
+                        "utf-8", errors="replace"
+                    )
+                )
+
+        # Check if it's computed (has a body)
+        if node.child_by_field_name("body"):
+            modifiers.add("computed")
+
+        modifiers.add("property")
+        return modifiers
+
+    def _extract_operator_modifiers(self, node: Node, byte_content: bytes) -> set:
+        """Extract operator-specific modifiers."""
+        modifiers = {"operator"}
+
+        # Check for prefix/infix/postfix
+        for child in node.children:
+            if child.type in ["prefix", "infix", "postfix"]:
+                modifiers.add(child.type)
+            elif byte_content[child.start_byte : child.end_byte].decode(
+                "utf-8", errors="replace"
+            ) in ["prefix", "infix", "postfix"]:
+                modifiers.add(
+                    byte_content[child.start_byte : child.end_byte].decode(
+                        "utf-8", errors="replace"
+                    )
+                )
+
+        return modifiers
+
+    def _extract_function_signature(self, node: Node, byte_content: bytes) -> str:
+        """Extract the function signature."""
+        # Get the text from function start to the opening brace
+        text = byte_content[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+        if "{" in text:
+            return text[: text.index("{")].strip()
+        return text.strip()
+
+    def _extract_docstring_for_node(self, node: Node, tree: Node, byte_content: bytes) -> str:
+        """Extract documentation comments for a specific node."""
+        doc_lines: List[str] = []
+
+        # Look for comments immediately before the node
+        line_before = node.start_point[0]
+
+        # Get all comments from the file
+        doc_query = self._get_compiled_query("doc_comments")
+        if doc_query:
+            captures = doc_query.captures(tree.root_node)
+
+            for comment_node, _capture_name in captures:
+                comment_line = comment_node.end_point[0]
+
+                # Check if this comment is right before our node
+                if comment_line == line_before - 1 or comment_line == line_before:
+                    comment_text = byte_content[
+                        comment_node.start_byte : comment_node.end_byte
+                    ].decode("utf-8", errors="replace")
+
+                    # Process documentation comments
+                    if comment_text.startswith("///"):
+                        doc_lines.append(comment_text[3:].strip())
+                    elif comment_text.startswith("/**") and comment_text.endswith("*/"):
+                        # Extract multi-line doc comment content
+                        content = comment_text[3:-2].strip()
+                        for line in content.split("\n"):
+                            line = line.strip()
+                            if line.startswith("*"):
+                                line = line[1:].strip()
+                            if line:
+                                doc_lines.append(line)
+
+        return "\n".join(doc_lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "codeconcat"
-version = "0.8.1"
+version = "0.8.2"
 description = "An LLM-friendly code aggregator and documentation extractor with advanced CLI"
 authors = ["Sergey Kornilov <sergey.kornilov@biostochastics.com>"]
 license = "MIT"


### PR DESCRIPTION
## **CodeAnt-AI Description**
• Introduces full Swift language support:
  – Adds `swift_parser.py`, a comprehensive regex-based Swift parser implementing `ParserInterface`.
  – Adds `tree_sitter_swift_parser.py`, a tree-sitter powered Swift parser with detailed queries for imports, declarations, doc-comments and modifiers.
  – Extends `REGEX_PARSER_MAP` and `TREE_SITTER_PARSER_MAP` in `language_parsers/__init__.py` to route `"swift"` to the new parsers.
• Updates project metadata and docs:
  – Bumps package version to 0.8.2 in `pyproject.toml`.
  – Revises README badges, language counts, feature tables and recent-updates section to reflect Swift (now 12+ languages) and new parser tier information.
• Minor logging and error-handling additions within the new parser modules for robustness.
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
