### PR TITLE
fix: allow framework route patterns in path validation

### DIFF
--- a/codeconcat/utils/security.py
+++ b/codeconcat/utils/security.py
@@ -42,7 +42,7 @@ class PathValidator:
 
     # Dangerous path patterns
     DANGEROUS_PATTERNS = [
-        r"\.\.",  # Parent directory
+        r"(?:^|[\\/])\.\.(?:[\\/]|$)",  # Parent directory as path component (../foo, foo/.., etc.)
         r"~",  # Home directory
         r"\$",  # Environment variables
         r"%",  # Windows environment variables


### PR DESCRIPTION
The path traversal regex was too broad - r"\.\." blocked any occurrence of ".." including valid Next.js catch-all routes like [[...slug]].

Changed to r"(?:^|[\\/])\.\.(?:[\\/]|$)" which only matches ".." when it appears as a standalone path component (actual traversal patterns).

Now correctly:
- Blocks: ../foo, foo/../bar, foo/.., ..\bar
- Allows: [[...slug]], [...slug], foo...bar, file..txt